### PR TITLE
refactor: upgrade quality standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@
 data/
 
 ###> friendsofphp/php-cs-fixer ###
-/.php-cs-fixer.php
+/.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 .idea
 
 data/
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,13 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,7 +7,8 @@ $finder = (new PhpCsFixer\Finder())
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@Symfony' => true,
+        '@PhpCsFixer' => true,
+        'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder($finder)
 ;

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,37 @@ unit-test: vendor ## Run PhpUnit unit testsuite
 	@$(call log_success,Done)
 
 .PHONY: func-test
-func-test: var/docker.up ## Run PhpUnit functionnal testsuite
+func-test: var/docker.up db-test ## Run PhpUnit functionnal testsuite
 	@$(call log,Running ...)
 	$(PHP_EXEC) bin/phpunit -v --testsuite func --testdox
+	@$(call log_success,Done)
+
+.PHONY: rector
+rector: var/docker.up
+	@$(call log,Running ...)
+	$(PHP_EXEC) vendor/bin/rector process --dry-run
+	@$(call log_success,Done)
+
+.PHONY: rector-fix
+rector-fix: var/docker.up
+	@$(call log,Running ...)
+	$(PHP_EXEC) vendor/bin/rector process
+	@$(call log_success,Done)
+
+.PHONY: cs
+cs: var/docker.up
+	@$(call log,Running ...)
+	$(PHP_EXEC) php vendor/bin/php-cs-fixer fix --dry-run --diff
+	@$(call log_success,Done)
+
+.PHONY: cs-fix
+cs-fix: var/docker.up
+	@$(call log,Running ...)
+	$(PHP_EXEC) php vendor/bin/php-cs-fixer fix
+	@$(call log_success,Done)
+
+.PHONY: phpstan
+phpstan: var/docker.up
+	@$(call log,Running ...)
+	$(PHP_EXEC) php vendor/bin/phpstan analyse
 	@$(call log_success,Done)

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,10 @@
         "friendsofphp/php-cs-fixer": "^3.13",
         "liip/functional-test-bundle": "^4.6",
         "liip/test-fixtures-bundle": "^2.4",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-doctrine": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "^6.1",
         "symfony/css-selector": "^6.1",
@@ -44,7 +48,8 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "phpstan/extension-installer": true
         },
         "optimize-autoloader": true,
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.4",
+        "friendsofphp/php-cs-fixer": "^3.13",
         "liip/functional-test-bundle": "^4.6",
         "liip/test-fixtures-bundle": "^2.4",
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^9.5",
+        "rector/rector": "^0.18.0",
         "symfony/browser-kit": "^6.1",
         "symfony/css-selector": "^6.1",
         "symfony/maker-bundle": "^1.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14b54bd98e5e4145750d00e699fbaf65",
+    "content-hash": "eb884bddb4ceaf2c7492de278833c827",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5185,6 +5185,224 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/pcre",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-17T09:50:14+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T19:23:25+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
             "name": "doctrine/data-fixtures",
             "version": "1.5.3",
             "source": {
@@ -5348,6 +5566,95 @@
                 }
             ],
             "time": "2022-04-28T17:58:29+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "3952f08a81bd3b1b15e11c3de0b6bf037faa8496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/3952f08a81bd3b1b15e11c3de0b6bf037faa8496",
+                "reference": "3952f08a81bd3b1b15e11c3de0b6bf037faa8496",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.2",
+                "composer/xdebug-handler": "^3.0.3",
+                "doctrine/annotations": "^1.13",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0",
+                "sebastian/diff": "^4.0",
+                "symfony/console": "^5.4 || ^6.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0",
+                "symfony/filesystem": "^5.4 || ^6.0",
+                "symfony/finder": "^5.4 || ^6.0",
+                "symfony/options-resolver": "^5.4 || ^6.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php81": "^1.25",
+                "symfony/process": "^5.4 || ^6.0",
+                "symfony/stopwatch": "^5.4 || ^6.0"
+            },
+            "require-dev": {
+                "justinrainbow/json-schema": "^5.2",
+                "keradus/cli-executor": "^2.0",
+                "mikey179/vfsstream": "^1.6.10",
+                "php-coveralls/php-coveralls": "^2.5.2",
+                "php-cs-fixer/accessible-object": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
+                "phpspec/prophecy": "^1.15",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "phpunitgoodpractices/polyfill": "^1.6",
+                "phpunitgoodpractices/traits": "^1.9.2",
+                "symfony/phpunit-bridge": "^6.0",
+                "symfony/yaml": "^5.4 || ^6.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.13.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-01-02T23:53:50+00:00"
         },
         {
             "name": "liip/functional-test-bundle",
@@ -7494,6 +7801,73 @@
                 }
             ],
             "time": "2023-07-10T18:21:57+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "a10f19f5198d589d5c33333cffe98dc9820332dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a10f19f5198d589d5c33333cffe98dc9820332dd",
+                "reference": "a10f19f5198d589d5c33333cffe98dc9820332dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-12T14:21:09+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbbfd74c9465c859935f17bdd2af7d28",
+    "content-hash": "1fb9f317089b28d143d1ad0c6fda8ff1",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -6784,6 +6784,62 @@
                 }
             ],
             "time": "2022-09-25T03:44:45+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "758ada29b5c80d933f906735d3026520390a2a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/758ada29b5c80d933f906735d3026520390a2a1d",
+                "reference": "758ada29b5c80d933f906735d3026520390a2a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.26"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.18.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-17T12:53:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb884bddb4ceaf2c7492de278833c827",
+    "content-hash": "bbbfd74c9465c859935f17bdd2af7d28",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -6117,6 +6117,253 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f45734bfb9984c6c56c4486b71230355f066a58a",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
+            },
+            "time": "2023-05-24T08:59:17+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-24T21:54:50+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "1.3.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "e4678fa1055bfd7fad052506b422aeae35fc6f63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/e4678fa1055bfd7fad052506b422aeae35fc6f63",
+                "reference": "e4678fa1055bfd7fad052506b422aeae35fc6f63",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.10.12"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "composer/semver": "^3.3.2",
+                "doctrine/annotations": "^1.11.0",
+                "doctrine/collections": "^1.6",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^2.13.8 || ^3.3.3",
+                "doctrine/lexer": "^1.2.1",
+                "doctrine/mongodb-odm": "^1.3 || ^2.1",
+                "doctrine/orm": "^2.11.0",
+                "doctrine/persistence": "^1.3.8 || ^2.2.1",
+                "gedmo/doctrine-extensions": "^3.8",
+                "nesbot/carbon": "^2.49",
+                "nikic/php-parser": "^4.13.2",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.5.10",
+                "ramsey/uuid-doctrine": "^1.5.0",
+                "symfony/cache": "^4.4.35"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.3.42"
+            },
+            "time": "2023-08-09T08:21:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "7332b90dfc291ac5b4b83fbca2081936faa1e3f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/7332b90dfc291ac5b4b83fbca2081936faa1e3f9",
+                "reference": "7332b90dfc291ac5b4b83fbca2081936faa1e3f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.18"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^8.5.29 || ^9.5",
+                "psr/container": "1.0 || 1.1.1",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^5.4"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.3.2"
+            },
+            "time": "2023-05-16T12:46:15+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -3,6 +3,7 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
         types:
             EventType: App\Entity\EventType
+        profiling: false
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)

--- a/migrations/Version20230826222439.php
+++ b/migrations/Version20230826222439.php
@@ -6,6 +6,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+
 final class Version20230826222439 extends AbstractMigration
 {
     public function getDescription(): string

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 8
+    paths:
+        - src/
+    symfony:
+        containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__.'/example',
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ]);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81,
+    ]);
+
+    $rectorConfig->skip([
+        ReadOnlyClassRector::class,
+    ]);
+};

--- a/src/Command/ImportGitHubEventsCommand.php
+++ b/src/Command/ImportGitHubEventsCommand.php
@@ -58,8 +58,8 @@ class ImportGitHubEventsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $date = $input->getArgument('date');
-        $hour = $input->getArgument('hour');
+        $date = (string) $input->getArgument('date');
+        $hour = (string) $input->getArgument('hour');
 
         $this->io = new SymfonyStyle($input, $output);
 
@@ -117,7 +117,6 @@ class ImportGitHubEventsCommand extends Command
         $repo = $this->fetchOrCreateRepo($ghArchiveEvent);
 
         $event = new Event(
-            null,
             $ghArchiveEvent->id,
             $this->eventTypeMapper->transformEventType($ghArchiveEvent->type),
             $actor,
@@ -136,7 +135,6 @@ class ImportGitHubEventsCommand extends Command
         $actor = $this->actorReadRepository->findOneBy(['ghaId' => $ghArchiveEvent->actorId]);
         if (!$actor instanceof Actor) {
             $actor = new Actor(
-                null,
                 $ghArchiveEvent->actorId,
                 $ghArchiveEvent->actorLogin,
                 $ghArchiveEvent->actorUrl,
@@ -153,7 +151,6 @@ class ImportGitHubEventsCommand extends Command
         $repo = $this->repoReadRepository->findOneBy(['ghaId' => $ghArchiveEvent->repoId]);
         if (!$repo instanceof Repo) {
             $repo = new Repo(
-                null,
                 $ghArchiveEvent->repoId,
                 $ghArchiveEvent->repoName,
                 $ghArchiveEvent->repoUrl

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -14,18 +14,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class EventController
 {
-    private WriteEventRepository $writeEventRepository;
-    private ReadEventRepository $readEventRepository;
-    private SerializerInterface $serializer;
-
-    public function __construct(
-        WriteEventRepository $writeEventRepository,
-        ReadEventRepository $readEventRepository,
-        SerializerInterface $serializer
-    ) {
-        $this->writeEventRepository = $writeEventRepository;
-        $this->readEventRepository = $readEventRepository;
-        $this->serializer = $serializer;
+    public function __construct(private readonly WriteEventRepository $writeEventRepository, private readonly ReadEventRepository $readEventRepository, private readonly SerializerInterface $serializer)
+    {
     }
 
     /**
@@ -53,7 +43,7 @@ class EventController
 
         try {
             $this->writeEventRepository->update($eventInput, $ghaId);
-        } catch (\Exception $exception) {
+        } catch (\Exception) {
             return new Response(null, Response::HTTP_SERVICE_UNAVAILABLE);
         }
 

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -6,8 +6,8 @@ use App\Dto\EventInput;
 use App\Repository\ReadEventRepository;
 use App\Repository\WriteEventRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -44,7 +44,7 @@ class EventController
             );
         }
 
-        if($this->readEventRepository->exist($ghaId) === false) {
+        if (false === $this->readEventRepository->exist($ghaId)) {
             return new JsonResponse(
                 ['message' => sprintf('Event identified by %d not found !', $ghaId)],
                 Response::HTTP_NOT_FOUND

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Dto\SearchInput;
 use App\Repository\ReadEventRepository;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,7 +16,7 @@ class SearchController
 
     public function __construct(
         ReadEventRepository $repository,
-        SerializerInterface  $serializer
+        SerializerInterface $serializer
     ) {
         $this->repository = $repository;
         $this->serializer = $serializer;
@@ -41,8 +40,8 @@ class SearchController
             ],
             'data' => [
                 'events' => $this->repository->getLatest($searchInput),
-                'stats' => $this->repository->statsByTypePerHour($searchInput)
-            ]
+                'stats' => $this->repository->statsByTypePerHour($searchInput),
+            ],
         ];
 
         return new JsonResponse($data);

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -11,15 +11,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class SearchController
 {
-    private ReadEventRepository $repository;
-    private SerializerInterface $serializer;
-
-    public function __construct(
-        ReadEventRepository $repository,
-        SerializerInterface $serializer
-    ) {
-        $this->repository = $repository;
-        $this->serializer = $serializer;
+    public function __construct(private readonly ReadEventRepository $repository, private readonly SerializerInterface $serializer)
+    {
     }
 
     /**

--- a/src/DataFixtures/EventFixtures.php
+++ b/src/DataFixtures/EventFixtures.php
@@ -15,21 +15,18 @@ class EventFixtures extends Fixture
     public const ACTOR_1_ID = 1;
     public const REPO_1_ID = 1;
 
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $event = new Event(
             self::EVENT_1_ID,
-            self::EVENT_1_ID,
             EventType::COMMENT,
             new Actor(
-                self::ACTOR_1_ID,
                 self::ACTOR_1_ID,
                 'jdoe',
                 'https://api.github.com/users/jdoe',
                 'https://avatars.githubusercontent.com/u/1?'
             ),
             new Repo(
-                self::REPO_1_ID,
                 self::REPO_1_ID,
                 'yousign/test',
                 'https://api.github.com/repos/yousign/backend-test'

--- a/src/DataFixtures/EventFixtures.php
+++ b/src/DataFixtures/EventFixtures.php
@@ -11,9 +11,9 @@ use Doctrine\Persistence\ObjectManager;
 
 class EventFixtures extends Fixture
 {
-    public const EVENT_1_ID = 1;
-    public const ACTOR_1_ID = 1;
-    public const REPO_1_ID = 1;
+    final public const EVENT_1_ID = 1;
+    final public const ACTOR_1_ID = 1;
+    final public const REPO_1_ID = 1;
 
     public function load(ObjectManager $manager): void
     {

--- a/src/Dto/EventInput.php
+++ b/src/Dto/EventInput.php
@@ -6,13 +6,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class EventInput
 {
-    /**
-     * @Assert\Length(min=20)
-     */
-    public ?string $comment;
-
-    public function __construct(?string $comment)
-    {
-        $this->comment = $comment;
+    public function __construct(
+        /**
+         * @Assert\Length(min=20)
+         */
+        public ?string $comment
+    ) {
     }
 }

--- a/src/Dto/EventInput.php
+++ b/src/Dto/EventInput.php
@@ -11,7 +11,8 @@ class EventInput
      */
     public ?string $comment;
 
-    public function __construct(?string $comment) {
+    public function __construct(?string $comment)
+    {
         $this->comment = $comment;
     }
 }

--- a/src/Dto/GHArchiveEntry.php
+++ b/src/Dto/GHArchiveEntry.php
@@ -4,6 +4,9 @@ namespace App\Dto;
 
 class GHArchiveEntry
 {
+    /**
+     * @param array<string, mixed> $payload
+     */
     public function __construct(
         public readonly int $id,
         public readonly string $type,

--- a/src/Dto/GHArchiveEntry.php
+++ b/src/Dto/GHArchiveEntry.php
@@ -2,8 +2,6 @@
 
 namespace App\Dto;
 
-use DateTimeImmutable;
-
 class GHArchiveEntry
 {
     public function __construct(
@@ -19,8 +17,7 @@ class GHArchiveEntry
         public readonly string $repoUrl,
         public readonly array $payload,
         public readonly bool $public,
-        public readonly DateTimeImmutable $createdAt
-    )
-    {
+        public readonly \DateTimeImmutable $createdAt
+    ) {
     }
 }

--- a/src/Entity/Actor.php
+++ b/src/Entity/Actor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+
 /**
  * @ORM\Entity()
  * @ORM\Table(
@@ -62,7 +63,6 @@ class Actor
         return $this->login;
     }
 
-
     public function url(): string
     {
         return $this->url;
@@ -82,5 +82,4 @@ class Actor
             $data['avatar_url']
         );
     }
-
 }

--- a/src/Entity/Actor.php
+++ b/src/Entity/Actor.php
@@ -24,32 +24,24 @@ class Actor
      */
     public int $id;
 
-    /**
-     * @ORM\Column(type="bigint")
-     */
-    public int $ghaId;
-
-    /**
-     * @ORM\Column(type="string")
-     */
-    public string $login;
-
-    /**
-     * @ORM\Column(type="string")
-     */
-    public string $url;
-
-    /**
-     * @ORM\Column(type="string")
-     */
-    public string $avatarUrl;
-
-    public function __construct(int $ghaId, string $login, string $url, string $avatarUrl)
-    {
-        $this->ghaId = $ghaId;
-        $this->login = $login;
-        $this->url = $url;
-        $this->avatarUrl = $avatarUrl;
+    public function __construct(
+        /**
+         * @ORM\Column(type="bigint")
+         */
+        public int $ghaId,
+        /**
+         * @ORM\Column(type="string")
+         */
+        public string $login,
+        /**
+         * @ORM\Column(type="string")
+         */
+        public string $url,
+        /**
+         * @ORM\Column(type="string")
+         */
+        public string $avatarUrl
+    ) {
     }
 
     public function id(): int

--- a/src/Entity/Actor.php
+++ b/src/Entity/Actor.php
@@ -22,7 +22,7 @@ class Actor
      * @ORM\Column(type="bigint")
      * @ORM\GeneratedValue
      */
-    public ?int $id;
+    public int $id;
 
     /**
      * @ORM\Column(type="bigint")
@@ -44,9 +44,8 @@ class Actor
      */
     public string $avatarUrl;
 
-    public function __construct(?int $id, int $ghaId, string $login, string $url, string $avatarUrl)
+    public function __construct(int $ghaId, string $login, string $url, string $avatarUrl)
     {
-        $this->id = $id;
         $this->ghaId = $ghaId;
         $this->login = $login;
         $this->url = $url;
@@ -71,15 +70,5 @@ class Actor
     public function avatarUrl(): string
     {
         return $this->avatarUrl;
-    }
-
-    public static function fromArray(array $data): self
-    {
-        return new self(
-            (int) $data['id'],
-            $data['login'],
-            $data['url'],
-            $data['avatar_url']
-        );
     }
 }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -22,7 +22,7 @@ class Event
      * @ORM\Column(type="bigint")
      * @ORM\GeneratedValue
      */
-    private ?int $id;
+    private int $id;
 
     /**
      * @ORM\Column(type="bigint")
@@ -53,6 +53,7 @@ class Event
 
     /**
      * @ORM\Column(type="json", nullable=false, options={"jsonb": true})
+     * @var array<string, mixed>
      */
     private array $payload;
 
@@ -66,9 +67,11 @@ class Event
      */
     private ?string $comment;
 
-    public function __construct(?int $id, int $ghaId, string $type, Actor $actor, Repo $repo, array $payload, \DateTimeImmutable $createAt, ?string $comment)
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(int $ghaId, string $type, Actor $actor, Repo $repo, array $payload, \DateTimeImmutable $createAt, ?string $comment)
     {
-        $this->id = $id;
         $this->ghaId = $ghaId;
         EventType::assertValidChoice($type);
         $this->type = $type;
@@ -103,6 +106,9 @@ class Event
         return $this->repo;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function payload(): array
     {
         return $this->payload;

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -25,11 +25,6 @@ class Event
     private int $id;
 
     /**
-     * @ORM\Column(type="bigint")
-     */
-    public int $ghaId;
-
-    /**
      * @ORM\Column(type="EventType", nullable=false)
      */
     private string $type;
@@ -40,46 +35,44 @@ class Event
     private int $count = 1;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Actor", cascade={"persist"})
-     * @ORM\JoinColumn(name="actor_id", referencedColumnName="id")
-     */
-    private Actor $actor;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Repo", cascade={"persist"})
-     * @ORM\JoinColumn(name="repo_id", referencedColumnName="id")
-     */
-    private Repo $repo;
-
-    /**
-     * @ORM\Column(type="json", nullable=false, options={"jsonb": true})
-     * @var array<string, mixed>
-     */
-    private array $payload;
-
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=false)
-     */
-    private \DateTimeImmutable $createAt;
-
-    /**
-     * @ORM\Column(type="text", nullable=true)
-     */
-    private ?string $comment;
-
-    /**
      * @param array<string, mixed> $payload
      */
-    public function __construct(int $ghaId, string $type, Actor $actor, Repo $repo, array $payload, \DateTimeImmutable $createAt, ?string $comment)
-    {
-        $this->ghaId = $ghaId;
+    public function __construct(
+        /**
+         * @ORM\Column(type="bigint")
+         */
+        public int $ghaId,
+        string $type,
+
+        /**
+         * @ORM\ManyToOne(targetEntity="App\Entity\Actor", cascade={"persist"})
+         * @ORM\JoinColumn(name="actor_id", referencedColumnName="id")
+         */
+        private Actor $actor,
+
+        /**
+         * @ORM\ManyToOne(targetEntity="App\Entity\Repo", cascade={"persist"})
+         * @ORM\JoinColumn(name="repo_id", referencedColumnName="id")
+         */
+        private Repo $repo,
+
+        /**
+         * @ORM\Column(type="json", nullable=false, options={"jsonb"=true})
+         */
+        private array $payload,
+
+        /**
+         * @ORM\Column(type="datetime_immutable", nullable=false)
+         */
+        private \DateTimeImmutable $createAt,
+
+        /**
+         * @ORM\Column(type="text", nullable=true)
+         */
+        private ?string $comment,
+    ) {
         EventType::assertValidChoice($type);
         $this->type = $type;
-        $this->actor = $actor;
-        $this->repo = $repo;
-        $this->payload = $payload;
-        $this->createAt = $createAt;
-        $this->comment = $comment;
 
         if (EventType::COMMIT === $type) {
             $this->count = $payload['size'] ?? 1;

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Webmozart\Assert\Assert;
 
 /**
  * @ORM\Entity()
@@ -79,7 +78,7 @@ class Event
         $this->createAt = $createAt;
         $this->comment = $comment;
 
-        if ($type === EventType::COMMIT) {
+        if (EventType::COMMIT === $type) {
             $this->count = $payload['size'] ?? 1;
         }
     }

--- a/src/Entity/EventType.php
+++ b/src/Entity/EventType.php
@@ -4,6 +4,9 @@ namespace App\Entity;
 
 use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
 
+/**
+ * @extends AbstractEnumType<string, string>
+ */
 class EventType extends AbstractEnumType
 {
     public const COMMIT = 'COM';

--- a/src/Entity/EventType.php
+++ b/src/Entity/EventType.php
@@ -9,9 +9,9 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  */
 class EventType extends AbstractEnumType
 {
-    public const COMMIT = 'COM';
-    public const COMMENT = 'MSG';
-    public const PULL_REQUEST = 'PR';
+    final public const COMMIT = 'COM';
+    final public const COMMENT = 'MSG';
+    final public const PULL_REQUEST = 'PR';
 
     protected static array $choices = [
         self::COMMIT => 'Commit',

--- a/src/Entity/Repo.php
+++ b/src/Entity/Repo.php
@@ -24,26 +24,20 @@ class Repo
      */
     private int $id;
 
-    /**
-     * @ORM\Column(type="bigint")
-     */
-    public int $ghaId;
-
-    /**
-     * @ORM\Column(type="string")
-     */
-    public string $name;
-
-    /**
-     * @ORM\Column(type="string")
-     */
-    public string $url;
-
-    public function __construct(int $ghaId, string $name, string $url)
-    {
-        $this->ghaId = $ghaId;
-        $this->name = $name;
-        $this->url = $url;
+    public function __construct(
+        /**
+         * @ORM\Column(type="bigint")
+         */
+        public int $ghaId,
+        /**
+         * @ORM\Column(type="string")
+         */
+        public string $name,
+        /**
+         * @ORM\Column(type="string")
+         */
+        public string $url
+    ) {
     }
 
     public function id(): int

--- a/src/Entity/Repo.php
+++ b/src/Entity/Repo.php
@@ -22,7 +22,7 @@ class Repo
      * @ORM\Column(type="bigint")
      * @ORM\GeneratedValue
      */
-    private ?int $id;
+    private int $id;
 
     /**
      * @ORM\Column(type="bigint")
@@ -39,9 +39,8 @@ class Repo
      */
     public string $url;
 
-    public function __construct(?int $id, int $ghaId, string $name, string $url)
+    public function __construct(int $ghaId, string $name, string $url)
     {
-        $this->id = $id;
         $this->ghaId = $ghaId;
         $this->name = $name;
         $this->url = $url;
@@ -60,14 +59,5 @@ class Repo
     public function url(): string
     {
         return $this->url;
-    }
-
-    public static function fromArray(array $data): self
-    {
-        return new self(
-            (int) $data['id'],
-            $data['name'],
-            $data['url']
-        );
     }
 }

--- a/src/Repository/DbalReadEventRepository.php
+++ b/src/Repository/DbalReadEventRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Dto\SearchInput;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 
 class DbalReadEventRepository implements ReadEventRepository
 {
@@ -28,6 +29,10 @@ SQL;
         ]);
     }
 
+    /**
+     * @return array<string, int>
+     * @throws Exception
+     */
     public function countByType(SearchInput $searchInput): array
     {
         $sql = <<<'SQL'
@@ -43,6 +48,9 @@ SQL;
         ]);
     }
 
+    /**
+     * @return array<array<string, int>>
+     */
     public function statsByTypePerHour(SearchInput $searchInput): array
     {
         $sql = <<<SQL
@@ -66,6 +74,10 @@ SQL;
         return $data;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     * @throws Exception
+     */
     public function getLatest(SearchInput $searchInput): array
     {
         $sql = <<<SQL

--- a/src/Repository/DbalReadEventRepository.php
+++ b/src/Repository/DbalReadEventRepository.php
@@ -8,11 +8,8 @@ use Doctrine\DBAL\Exception;
 
 class DbalReadEventRepository implements ReadEventRepository
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function countAll(SearchInput $searchInput): int
@@ -31,6 +28,7 @@ SQL;
 
     /**
      * @return array<string, int>
+     *
      * @throws Exception
      */
     public function countByType(SearchInput $searchInput): array
@@ -76,6 +74,7 @@ SQL;
 
     /**
      * @return array<array<string, mixed>>
+     *
      * @throws Exception
      */
     public function getLatest(SearchInput $searchInput): array
@@ -92,18 +91,16 @@ SQL;
             'keyword' => $searchInput->keyword,
         ]);
 
-        $result = array_map(static function ($item) {
-            $item['repo'] = json_decode($item['repo'], true);
+        return array_map(static function ($item) {
+            $item['repo'] = json_decode((string) $item['repo'], true, flags: JSON_THROW_ON_ERROR);
 
             return $item;
         }, $result);
-
-        return $result;
     }
 
     public function exist(int $ghaId): bool
     {
-        $sql = <<<SQL
+        $sql = <<<'SQL'
             SELECT 1
             FROM event
             WHERE gha_id = :ghaId

--- a/src/Repository/DbalReadEventRepository.php
+++ b/src/Repository/DbalReadEventRepository.php
@@ -24,7 +24,7 @@ class DbalReadEventRepository implements ReadEventRepository
 SQL;
 
         return (int) $this->connection->fetchOne($sql, [
-            'date' => $searchInput->date
+            'date' => $searchInput->date,
         ]);
     }
 
@@ -39,7 +39,7 @@ SQL;
 SQL;
 
         return $this->connection->fetchAllKeyValue($sql, [
-            'date' => $searchInput->date
+            'date' => $searchInput->date,
         ]);
     }
 
@@ -54,7 +54,7 @@ SQL;
 SQL;
 
         $stats = $this->connection->fetchAll($sql, [
-            'date' => $searchInput->date
+            'date' => $searchInput->date,
         ]);
 
         $data = array_fill(0, 24, ['commit' => 0, 'pullRequest' => 0, 'comment' => 0]);
@@ -80,7 +80,7 @@ SQL;
             'keyword' => $searchInput->keyword,
         ]);
 
-        $result = array_map(static function($item) {
+        $result = array_map(static function ($item) {
             $item['repo'] = json_decode($item['repo'], true);
 
             return $item;
@@ -98,7 +98,7 @@ SQL;
         SQL;
 
         $result = $this->connection->fetchOne($sql, [
-            'ghaId' => $ghaId
+            'ghaId' => $ghaId,
         ]);
 
         return (bool) $result;

--- a/src/Repository/DbalWriteEventRepository.php
+++ b/src/Repository/DbalWriteEventRepository.php
@@ -7,16 +7,13 @@ use Doctrine\DBAL\Connection;
 
 class DbalWriteEventRepository implements WriteEventRepository
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function update(EventInput $authorInput, int $id): void
     {
-        $sql = <<<SQL
+        $sql = <<<'SQL'
         UPDATE event
         SET comment = :comment
         WHERE id = :id

--- a/src/Repository/DbalWriteEventRepository.php
+++ b/src/Repository/DbalWriteEventRepository.php
@@ -3,9 +3,7 @@
 namespace App\Repository;
 
 use App\Dto\EventInput;
-use App\Dto\SearchInput;
 use Doctrine\DBAL\Connection;
-use phpDocumentor\Reflection\DocBlock\Tags\Author;
 
 class DbalWriteEventRepository implements WriteEventRepository
 {

--- a/src/Repository/ReadActorRepository.php
+++ b/src/Repository/ReadActorRepository.php
@@ -28,7 +28,8 @@ class ReadActorRepository extends ServiceEntityRepository
             ->select('COUNT(a.id)')
             ->where('a.ghaId = :ghaId')
             ->setParameter('ghaId', $ghaId)
-            ->getQuery();
+            ->getQuery()
+        ;
 
         return 1 === $query->getSingleScalarResult();
     }

--- a/src/Repository/ReadActorRepository.php
+++ b/src/Repository/ReadActorRepository.php
@@ -4,8 +4,13 @@ namespace App\Repository;
 
 use App\Entity\Actor;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends ServiceEntityRepository<Actor>
+ */
 class ReadActorRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
@@ -13,6 +18,10 @@ class ReadActorRepository extends ServiceEntityRepository
         parent::__construct($registry, Actor::class);
     }
 
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
     public function exists(string $ghaId): bool
     {
         $query = $this->createQueryBuilder('a')
@@ -21,6 +30,6 @@ class ReadActorRepository extends ServiceEntityRepository
             ->setParameter('ghaId', $ghaId)
             ->getQuery();
 
-        return 1 === $query->getScalarResult();
+        return 1 === $query->getSingleScalarResult();
     }
 }

--- a/src/Repository/ReadActorRepository.php
+++ b/src/Repository/ReadActorRepository.php
@@ -8,7 +8,6 @@ use Doctrine\Persistence\ManagerRegistry;
 
 class ReadActorRepository extends ServiceEntityRepository
 {
-
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Actor::class);
@@ -22,6 +21,6 @@ class ReadActorRepository extends ServiceEntityRepository
             ->setParameter('ghaId', $ghaId)
             ->getQuery();
 
-        return $query->getScalarResult() === 1;
+        return 1 === $query->getScalarResult();
     }
 }

--- a/src/Repository/ReadEventRepository.php
+++ b/src/Repository/ReadEventRepository.php
@@ -7,8 +7,12 @@ use App\Dto\SearchInput;
 interface ReadEventRepository
 {
     public function countAll(SearchInput $searchInput): int;
+
     public function countByType(SearchInput $searchInput): array;
+
     public function statsByTypePerHour(SearchInput $searchInput): array;
+
     public function getLatest(SearchInput $searchInput): array;
+
     public function exist(int $ghaId): bool;
 }

--- a/src/Repository/ReadEventRepository.php
+++ b/src/Repository/ReadEventRepository.php
@@ -8,10 +8,19 @@ interface ReadEventRepository
 {
     public function countAll(SearchInput $searchInput): int;
 
+    /**
+     * @return array<string, int>
+     */
     public function countByType(SearchInput $searchInput): array;
 
+    /**
+     * @return array<array<string, int>>
+     */
     public function statsByTypePerHour(SearchInput $searchInput): array;
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function getLatest(SearchInput $searchInput): array;
 
     public function exist(int $ghaId): bool;

--- a/src/Repository/ReadRepoRepository.php
+++ b/src/Repository/ReadRepoRepository.php
@@ -6,6 +6,9 @@ use App\Entity\Repo;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends ServiceEntityRepository<Repo>
+ */
 class ReadRepoRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
@@ -21,6 +24,6 @@ class ReadRepoRepository extends ServiceEntityRepository
             ->setParameter('ghaId', $ghaId)
             ->getQuery();
 
-        return 1 === $query->getScalarResult();
+        return 1 === (int) $query->getScalarResult();
     }
 }

--- a/src/Repository/ReadRepoRepository.php
+++ b/src/Repository/ReadRepoRepository.php
@@ -8,7 +8,6 @@ use Doctrine\Persistence\ManagerRegistry;
 
 class ReadRepoRepository extends ServiceEntityRepository
 {
-
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Repo::class);
@@ -22,6 +21,6 @@ class ReadRepoRepository extends ServiceEntityRepository
             ->setParameter('ghaId', $ghaId)
             ->getQuery();
 
-        return $query->getScalarResult() === 1;
+        return 1 === $query->getScalarResult();
     }
 }

--- a/src/Repository/ReadRepoRepository.php
+++ b/src/Repository/ReadRepoRepository.php
@@ -22,7 +22,8 @@ class ReadRepoRepository extends ServiceEntityRepository
             ->select('COUNT(r.id)')
             ->where('r.ghaId = :ghaId')
             ->setParameter('ghaId', $ghaId)
-            ->getQuery();
+            ->getQuery()
+        ;
 
         return 1 === (int) $query->getScalarResult();
     }

--- a/src/Serializer/GHArchiveEventDenormalizer.php
+++ b/src/Serializer/GHArchiveEventDenormalizer.php
@@ -13,9 +13,10 @@ class GHArchiveEventDenormalizer implements DenormalizerInterface
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): GHArchiveEntry
     {
         $createdAt = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s\Z', $data['created_at']);
-        if ($createdAt === false) {
+        if (false === $createdAt) {
             throw new \RuntimeException('Unable to convert date string to DateTimeInterface object');
         }
+
         return new GHArchiveEntry(
             $data['id'],
             $data['type'],

--- a/src/Serializer/GHArchiveEventDenormalizer.php
+++ b/src/Serializer/GHArchiveEventDenormalizer.php
@@ -3,39 +3,37 @@
 namespace App\Serializer;
 
 use App\Dto\GHArchiveEntry;
-use DateTimeImmutable;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class GHArchiveEventDenormalizer implements DenormalizerInterface
 {
-
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): GHArchiveEntry
     {
         return new GHArchiveEntry(
-            $data["id"],
-            $data["type"],
-            $data["actor"]["id"],
-            $data["actor"]["login"],
-            $data["actor"]["gravatar_id"],
-            $data["actor"]["url"],
-            $data["actor"]["avatar_url"],
-            $data["repo"]["id"],
-            $data["repo"]["name"],
-            $data["repo"]["url"],
-            $data["payload"],
-            $data["public"],
-            DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s\Z', $data["created_at"]),
+            $data['id'],
+            $data['type'],
+            $data['actor']['id'],
+            $data['actor']['login'],
+            $data['actor']['gravatar_id'],
+            $data['actor']['url'],
+            $data['actor']['avatar_url'],
+            $data['repo']['id'],
+            $data['repo']['name'],
+            $data['repo']['url'],
+            $data['payload'],
+            $data['public'],
+            \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s\Z', $data['created_at']),
         );
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
     {
-        return $type === GHArchiveEntry::class;
+        return GHArchiveEntry::class === $type;
     }
 }

--- a/src/Serializer/GHArchiveEventDenormalizer.php
+++ b/src/Serializer/GHArchiveEventDenormalizer.php
@@ -12,6 +12,10 @@ class GHArchiveEventDenormalizer implements DenormalizerInterface
      */
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): GHArchiveEntry
     {
+        $createdAt = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s\Z', $data['created_at']);
+        if ($createdAt === false) {
+            throw new \RuntimeException('Unable to convert date string to DateTimeInterface object');
+        }
         return new GHArchiveEntry(
             $data['id'],
             $data['type'],
@@ -25,7 +29,7 @@ class GHArchiveEventDenormalizer implements DenormalizerInterface
             $data['repo']['url'],
             $data['payload'],
             $data['public'],
-            \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s\Z', $data['created_at']),
+            $createdAt,
         );
     }
 

--- a/src/Service/DataFetcher/GhArchiveDataFetcher.php
+++ b/src/Service/DataFetcher/GhArchiveDataFetcher.php
@@ -2,17 +2,14 @@
 
 namespace App\Service\DataFetcher;
 
-use RuntimeException;
-
 interface GhArchiveDataFetcher
 {
-    const DATA_DIR = __DIR__ . '/../../../data/';
+    public const DATA_DIR = __DIR__.'/../../../data/';
 
     /**
-     * @param string $date
-     * @param string $hour
      * @return string The path to the json file containing the data
-     * @throws RuntimeException
+     *
+     * @throws \RuntimeException
      */
     public function fetchData(string $date, string $hour): string;
 }

--- a/src/Service/DataFetcher/GhArchiveFetcherGateway.php
+++ b/src/Service/DataFetcher/GhArchiveFetcherGateway.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\DataFetcher;
 
-use RuntimeException;
 use Throwable;
 
 class GhArchiveFetcherGateway implements GhArchiveDataFetcher
@@ -10,20 +9,20 @@ class GhArchiveFetcherGateway implements GhArchiveDataFetcher
     public function __construct(
         private readonly LocalGhArchiveFetcher $localGhArchiveFetcher,
         private readonly OnlineGhArchiveFetcher $onlineGhArchiveFetcher,
-    )
-    {
+    ) {
     }
 
     public function fetchData(string $date, string $hour): string
     {
         try {
             return $this->localGhArchiveFetcher->fetchData($date, $hour);
-        } catch (Throwable) {}
+        } catch (Throwable) {
+        }
 
         try {
             return $this->onlineGhArchiveFetcher->fetchData($date, $hour);
         } catch (Throwable) {
-            throw new RuntimeException("Impossible to fetch data locally and online");
+            throw new \RuntimeException('Impossible to fetch data locally and online');
         }
     }
 }

--- a/src/Service/DataFetcher/LocalGhArchiveFetcher.php
+++ b/src/Service/DataFetcher/LocalGhArchiveFetcher.php
@@ -3,7 +3,6 @@
 namespace App\Service\DataFetcher;
 
 use App\Service\GHArchiveFilenameBuilder;
-use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class LocalGhArchiveFetcher implements GhArchiveDataFetcher
@@ -11,16 +10,15 @@ class LocalGhArchiveFetcher implements GhArchiveDataFetcher
     public function __construct(
         private readonly Filesystem $filesystem,
         private readonly GHArchiveFilenameBuilder $filenameBuilder,
-    )
-    {
+    ) {
     }
 
     public function fetchData(string $date, string $hour): string
     {
-        $dataFilePath = self::DATA_DIR . $this->filenameBuilder->buildFilename($date, $hour);
+        $dataFilePath = self::DATA_DIR.$this->filenameBuilder->buildFilename($date, $hour);
 
         if (!$this->filesystem->exists($dataFilePath)) {
-            throw new RuntimeException("local data file not found on system");
+            throw new \RuntimeException('local data file not found on system');
         }
 
         return $dataFilePath;

--- a/src/Service/DataFetcher/OnlineGhArchiveFetcher.php
+++ b/src/Service/DataFetcher/OnlineGhArchiveFetcher.php
@@ -16,17 +16,16 @@ class OnlineGhArchiveFetcher implements GhArchiveDataFetcher
         private readonly TemporaryFileWriter $fileWriter,
         private readonly FileUncompressor $fileUncompressor,
         private readonly Filesystem $filesystem,
-    )
-    {
+    ) {
     }
 
     public function fetchData(string $date, string $hour): string
     {
         $dataFileName = $this->filenameBuilder->buildFilename($date, $hour);
-        $content = $this->archiveDownloader->downloadCompressed($dataFileName . ".gz");
-        $tempFilePath = $this->fileWriter->writeContentToTempFile($content, "gharchive_", ".json.gz");
+        $content = $this->archiveDownloader->downloadCompressed($dataFileName.'.gz');
+        $tempFilePath = $this->fileWriter->writeContentToTempFile($content, 'gharchive_', '.json.gz');
 
-        $dataFilePath = self::DATA_DIR . $dataFileName;
+        $dataFilePath = self::DATA_DIR.$dataFileName;
         $this->fileUncompressor->uncompressFile($tempFilePath, $dataFilePath);
 
         $this->filesystem->remove($tempFilePath);

--- a/src/Service/FileReader.php
+++ b/src/Service/FileReader.php
@@ -7,9 +7,10 @@ class FileReader
     /**
      * @return iterable<string>
      */
-    public function getIterator(string $filePath): iterable {
-        if ($file = fopen($filePath, "r")) {
-            while(!feof($file)) {
+    public function getIterator(string $filePath): iterable
+    {
+        if ($file = fopen($filePath, 'r')) {
+            while (!feof($file)) {
                 if (($line = fgets($file)) !== false) {
                     yield $line;
                 }

--- a/src/Service/FileUncompressor.php
+++ b/src/Service/FileUncompressor.php
@@ -20,7 +20,7 @@ class FileUncompressor
             $out_file = fopen($outputPath, 'wb');
             $file = gzopen($compressedFiledPath, 'rb');
 
-            if ($out_file === false || $file === false) {
+            if (false === $out_file || false === $file) {
                 throw new \RuntimeException('An error occurred when opening stream for compressed file or destination file');
             }
 

--- a/src/Service/FileUncompressor.php
+++ b/src/Service/FileUncompressor.php
@@ -20,8 +20,14 @@ class FileUncompressor
             $out_file = fopen($outputPath, 'wb');
             $file = gzopen($compressedFiledPath, 'rb');
 
+            if ($out_file === false || $file === false) {
+                throw new \RuntimeException('An error occurred when opening stream for compressed file or destination file');
+            }
+
             while (!gzeof($file)) {
-                fwrite($out_file, gzread($file, $this->bufferSize));
+                if (($readBuffer = gzread($file, $this->bufferSize)) !== false) {
+                    fwrite($out_file, $readBuffer);
+                }
             }
 
             fclose($out_file);

--- a/src/Service/FileUncompressor.php
+++ b/src/Service/FileUncompressor.php
@@ -2,22 +2,20 @@
 
 namespace App\Service;
 
-use RuntimeException;
-use Throwable;
-
 class FileUncompressor
 {
     public function __construct(
         private readonly int $bufferSize = 4096,
-    )
-    {
+    ) {
     }
 
     /**
-     * Uncompress a file into the specified output path
-     * @throws RuntimeException
+     * Uncompress a file into the specified output path.
+     *
+     * @throws \RuntimeException
      */
-    public function uncompressFile(string $compressedFiledPath, string $outputPath): void {
+    public function uncompressFile(string $compressedFiledPath, string $outputPath): void
+    {
         try {
             $out_file = fopen($outputPath, 'wb');
             $file = gzopen($compressedFiledPath, 'rb');
@@ -28,9 +26,8 @@ class FileUncompressor
 
             fclose($out_file);
             gzclose($file);
-        } catch (Throwable $throwable) {
-            throw new RuntimeException("An error occurred when uncompressing file", previous: $throwable);
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException('An error occurred when uncompressing file', previous: $throwable);
         }
-
     }
 }

--- a/src/Service/GHArchiveDownloader.php
+++ b/src/Service/GHArchiveDownloader.php
@@ -2,10 +2,8 @@
 
 namespace App\Service;
 
-use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Throwable;
 
 class GHArchiveDownloader
 {
@@ -17,23 +15,22 @@ class GHArchiveDownloader
 
     /**
      * @param string $fileName Compressed file to download
+     *
      * @return string The content of the compressed file as a string
-     * @throws RuntimeException
+     *
+     * @throws \RuntimeException
      */
     public function downloadCompressed(string $fileName): string
     {
         try {
-            $response = $this->httpClient->request('GET', self::BASE_URL . $fileName);
+            $response = $this->httpClient->request('GET', self::BASE_URL.$fileName);
             if (($statusCode = $response->getStatusCode()) !== Response::HTTP_OK) {
-                throw new RuntimeException('Bad response code from gharchive', $statusCode);
+                throw new \RuntimeException('Bad response code from gharchive', $statusCode);
             }
 
             return $response->getContent();
-        } catch (Throwable $throwable) {
-            throw new RuntimeException(
-                'Error when fetching gharchive compressed data',
-                previous: $throwable
-            );
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException('Error when fetching gharchive compressed data', previous: $throwable);
         }
     }
 }

--- a/src/Service/GHArchiveEventTypeMapper.php
+++ b/src/Service/GHArchiveEventTypeMapper.php
@@ -3,18 +3,17 @@
 namespace App\Service;
 
 use App\Entity\EventType;
-use RuntimeException;
 
 class GHArchiveEventTypeMapper
 {
     public function isEventTypeAllowed(string $type): bool
     {
         $allowedTypes = [
-            "CommitCommentEvent",
-            "IssueCommentEvent",
-            "PullRequestReviewCommentEvent",
-            "PushEvent",
-            "PullRequestEvent"
+            'CommitCommentEvent',
+            'IssueCommentEvent',
+            'PullRequestReviewCommentEvent',
+            'PushEvent',
+            'PullRequestEvent',
         ];
 
         return in_array($type, $allowedTypes);
@@ -22,15 +21,16 @@ class GHArchiveEventTypeMapper
 
     /**
      * @return string The corresponding event type for entity
-     * @throws RuntimeException
+     *
+     * @throws \RuntimeException
      */
-    public function transformEventType(string $ghArchiveType): string {
-
+    public function transformEventType(string $ghArchiveType): string
+    {
         return match ($ghArchiveType) {
-            "CommitCommentEvent", "IssueCommentEvent", "PullRequestReviewCommentEvent" => EventType::COMMENT,
-            "PullRequestEvent" => EventType::PULL_REQUEST,
-            "PushEvent" => EventType::COMMIT,
-            default => throw new RuntimeException('Unknown ghArchive type')
+            'CommitCommentEvent', 'IssueCommentEvent', 'PullRequestReviewCommentEvent' => EventType::COMMENT,
+            'PullRequestEvent' => EventType::PULL_REQUEST,
+            'PushEvent' => EventType::COMMIT,
+            default => throw new \RuntimeException('Unknown ghArchive type')
         };
     }
 }

--- a/src/Service/GHArchiveFilenameBuilder.php
+++ b/src/Service/GHArchiveFilenameBuilder.php
@@ -6,6 +6,6 @@ class GHArchiveFilenameBuilder
 {
     public function buildFilename(string $date, string $hour): string
     {
-        return "$date-$hour.json";
+        return "{$date}-{$hour}.json";
     }
 }

--- a/src/Service/GHArchiveFilenameBuilder.php
+++ b/src/Service/GHArchiveFilenameBuilder.php
@@ -4,7 +4,8 @@ namespace App\Service;
 
 class GHArchiveFilenameBuilder
 {
-    public function buildFilename(string $date, string $hour): string {
+    public function buildFilename(string $date, string $hour): string
+    {
         return "$date-$hour.json";
     }
 }

--- a/src/Service/TemporaryFileWriter.php
+++ b/src/Service/TemporaryFileWriter.php
@@ -13,7 +13,8 @@ class TemporaryFileWriter
     /**
      * @return string the path of the created temp file
      */
-    public function writeContentToTempFile(string $content, string $prefix, string $suffix): string {
+    public function writeContentToTempFile(string $content, string $prefix, string $suffix): string
+    {
         $tempFilePath = $this->filesystem->tempnam(sys_get_temp_dir(), $prefix, $suffix);
         $this->filesystem->dumpFile($tempFilePath, $content);
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -153,6 +153,18 @@
     "phpstan/phpdoc-parser": {
         "version": "1.2.0"
     },
+    "phpstan/phpstan": {
+        "version": "1.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "d74d4d719d5f53856c9c13544aa22d44144b1819"
+        },
+        "files": [
+            "phpstan.neon"
+        ]
+    },
     "phpunit/php-code-coverage": {
         "version": "9.2.11"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -102,6 +102,18 @@
             "src/DBAL/Types/.gitignore"
         ]
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.13",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "be2103eb4a20942e28a6dd87736669b757132435"
+        },
+        "files": [
+            ".php-cs-fixer.dist.php"
+        ]
+    },
     "friendsofphp/proxy-manager-lts": {
         "version": "v1.0.3"
     },

--- a/tests/Func/Command/ImportGitHubEventsCommandTest.php
+++ b/tests/Func/Command/ImportGitHubEventsCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Func\Command;
+
+use App\Entity\Event;
+use App\Repository\ReadEventRepository;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ImportGitHubEventsCommandTest extends KernelTestCase
+{
+    private const SOURCE_FILE_PATH = __DIR__. '/../../data/2015-01-01-1.json';
+    private const DESTINATION_FILE_PATH = __DIR__.'/../../../data/2015-01-01-1.json';
+
+    private CommandTester $commandTester;
+
+    private Filesystem $fileSystem;
+
+    private ReadEventRepository $readEventRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $this->fileSystem = self::getContainer()->get('filesystem');
+        echo $kernel->getEnvironment();
+        $this->fileSystem->copy(self::SOURCE_FILE_PATH, self::DESTINATION_FILE_PATH);
+
+        $this->readEventRepository = self::getContainer()->get(ReadEventRepository::class);
+
+        $command = $application->find('app:import-github-events');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fileSystem->remove(self::DESTINATION_FILE_PATH);
+        parent::tearDown();
+    }
+
+    public function testExecute(): void
+    {
+        $this->commandTester->execute([
+            "date" => "2015-01-01",
+            "hour" => "12"
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+        self::assertTrue($this->readEventRepository->exist(2489418153));
+    }
+
+    /**
+     * @dataProvider provideMissingArguments
+     */
+    public function testItThrowsExceptionWithoutAllArgs(array $args): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->commandTester->execute($args);
+
+        // the output of the command in the console
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Username: Wouter', $output);
+    }
+
+    private function provideMissingArguments(): iterable
+    {
+        yield "No arg" => [[]];
+        yield "Date only" => [["date" => "2015-01-01"]];
+        yield "Hour only" => [["hour" => "23"]];
+    }
+
+    /**
+     * @dataProvider provideBadArguments
+     */
+    public function testItReturnsInvalidCodeWithBadArgs(array $args): void
+    {
+        $this->commandTester->execute($args);
+
+        $this->assertEquals(Command::INVALID, $this->commandTester->getStatusCode());
+
+        // the output of the command in the console
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Bad formatted arguments.', $output);
+    }
+
+    private function provideBadArguments(): iterable
+    {
+        yield "Bad Date" => [[
+            "date" => "2015a-01-01",
+            "hour" => "23"
+        ]];
+        yield "Bad Hour" => [[
+            "date" => "2015-01-01",
+            "hour" => "25"
+        ]];
+    }
+}

--- a/tests/Func/EventControllerTest.php
+++ b/tests/Func/EventControllerTest.php
@@ -3,11 +3,10 @@
 namespace App\Tests\Func;
 
 use App\DataFixtures\EventFixtures;
-use App\Entity\Event;
 use Doctrine\ORM\Tools\SchemaTool;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class EventControllerTest extends WebTestCase
 {
@@ -45,7 +44,6 @@ class EventControllerTest extends WebTestCase
 
         $this->assertResponseStatusCodeSame(204);
     }
-
 
     public function testUpdateShouldReturnHttpNotFoundResponse()
     {
@@ -89,7 +87,6 @@ class EventControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(400);
         self::assertJsonStringEqualsJsonString($expectedResponse, $client->getResponse()->getContent());
-
     }
 
     public function providePayloadViolations(): iterable

--- a/tests/Func/EventControllerTest.php
+++ b/tests/Func/EventControllerTest.php
@@ -8,10 +8,15 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class EventControllerTest extends WebTestCase
 {
     protected AbstractDatabaseTool $databaseTool;
-    private static $client;
+    private static \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
 
     protected function setUp(): void
     {
@@ -51,7 +56,7 @@ class EventControllerTest extends WebTestCase
 
         $client->request(
             'PUT',
-            sprintf('/api/event/%d/update', 7897897897),
+            sprintf('/api/event/%d/update', 7_897_897_897),
             [],
             [],
             ['CONTENT_TYPE' => 'application/json'],
@@ -60,7 +65,7 @@ class EventControllerTest extends WebTestCase
 
         $this->assertResponseStatusCodeSame(404);
 
-        $expectedJson = <<<JSON
+        $expectedJson = <<<'JSON'
               {
                 "message":"Event identified by 7897897897 not found !"
               }
@@ -92,13 +97,13 @@ class EventControllerTest extends WebTestCase
     public function providePayloadViolations(): iterable
     {
         yield 'comment too short' => [
-            <<<JSON
+            <<<'JSON'
               {
                 "comment": "short"
                 
             }
             JSON,
-            <<<JSON
+            <<<'JSON'
                 {
                     "message": "This value is too short. It should have 20 characters or more."
                 }

--- a/tests/Unit/Service/FileReaderTest.php
+++ b/tests/Unit/Service/FileReaderTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Unit\Service;
 use App\Service\FileReader;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class FileReaderTest extends TestCase
 {
     private FileReader $testedInstance;

--- a/tests/Unit/Service/FileReaderTest.php
+++ b/tests/Unit/Service/FileReaderTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 class FileReaderTest extends TestCase
 {
-
     private FileReader $testedInstance;
 
     protected function setUp(): void
@@ -17,7 +16,7 @@ class FileReaderTest extends TestCase
 
     public function testGetIterator(): void
     {
-        $filePath = __DIR__ . "/../../data/test.txt";
+        $filePath = __DIR__.'/../../data/test.txt';
         $lines = [...$this->testedInstance->getIterator($filePath)];
         $this->assertEquals("azerty\n", $lines[0]);
         $this->assertEquals("123456\n", $lines[1]);

--- a/tests/Unit/Service/FileUncompressorTest.php
+++ b/tests/Unit/Service/FileUncompressorTest.php
@@ -4,7 +4,6 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\FileUncompressor;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 class FileUncompressorTest extends TestCase
 {
@@ -17,9 +16,9 @@ class FileUncompressorTest extends TestCase
 
     public function testUncompressFile(): void
     {
-        $filePath = __DIR__ . "/../../data/test.txt.gz";
-        $originalFilePath = __DIR__ . "/../../data/test.txt";
-        $outputPath = sys_get_temp_dir() . "/result";
+        $filePath = __DIR__.'/../../data/test.txt.gz';
+        $originalFilePath = __DIR__.'/../../data/test.txt';
+        $outputPath = sys_get_temp_dir().'/result';
 
         $this->testedInstance->uncompressFile($filePath, $outputPath);
 
@@ -28,10 +27,10 @@ class FileUncompressorTest extends TestCase
 
     public function testItThrowExceptionWhenFileIsNotFound(): void
     {
-        $filePath = __DIR__ . "/../../data/unknownFile.txt.gz";
-        $outputPath = sys_get_temp_dir() . "/result";
+        $filePath = __DIR__.'/../../data/unknownFile.txt.gz';
+        $outputPath = sys_get_temp_dir().'/result';
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(\RuntimeException::class);
         $this->testedInstance->uncompressFile($filePath, $outputPath);
     }
 }

--- a/tests/Unit/Service/FileUncompressorTest.php
+++ b/tests/Unit/Service/FileUncompressorTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Unit\Service;
 use App\Service\FileUncompressor;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class FileUncompressorTest extends TestCase
 {
     private FileUncompressor $testedInstance;

--- a/tests/Unit/Service/GHArchiveDownloaderTest.php
+++ b/tests/Unit/Service/GHArchiveDownloaderTest.php
@@ -7,6 +7,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class GHArchiveDownloaderTest extends TestCase
 {
     public function testDownloadCompressed(): void

--- a/tests/Unit/Service/GHArchiveDownloaderTest.php
+++ b/tests/Unit/Service/GHArchiveDownloaderTest.php
@@ -3,9 +3,7 @@
 namespace App\Tests\Unit\Service;
 
 use App\Service\GHArchiveDownloader;
-use Exception;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -14,36 +12,36 @@ class GHArchiveDownloaderTest extends TestCase
     public function testDownloadCompressed(): void
     {
         $client = new MockHttpClient([
-            new MockResponse($data = uniqid('data', true))
+            new MockResponse($data = uniqid('data', true)),
         ]);
 
         $testedInstance = new GHArchiveDownloader($client);
 
-        $content = $testedInstance->downloadCompressed(uniqid("file_", true));
+        $content = $testedInstance->downloadCompressed(uniqid('file_', true));
         self::assertEquals($data, $content);
     }
 
     public function testDownloadWhenExceptionOccurs(): void
     {
         $client = new MockHttpClient([
-            new MockResponse([new RuntimeException('Error at transport level')]),
+            new MockResponse([new \RuntimeException('Error at transport level')]),
         ]);
 
         $testedInstance = new GHArchiveDownloader($client);
 
-        $this->expectException(RuntimeException::class);
-        $testedInstance->downloadCompressed(uniqid("file_", true));
+        $this->expectException(\RuntimeException::class);
+        $testedInstance->downloadCompressed(uniqid('file_', true));
     }
 
     public function testDownloadWithBadResponseCode(): void
     {
         $client = new MockHttpClient([
-            new MockResponse("", ['http_code' => 404])
+            new MockResponse('', ['http_code' => 404]),
         ]);
 
         $testedInstance = new GHArchiveDownloader($client);
 
-        $this->expectException(RuntimeException::class);
-        $testedInstance->downloadCompressed(uniqid("file_", true));
+        $this->expectException(\RuntimeException::class);
+        $testedInstance->downloadCompressed(uniqid('file_', true));
     }
 }


### PR DESCRIPTION
# Why
As asked in the subject, it could be nice to refactor the codebase to meet a certain standard of code quality.

# How
* Add tools such as phpstan, cs-fixer and rector to make code more robust and readable.
* Add new makefile targets for these tools.
* Tried to write a functional test for the command that is nearly working, but do not understand why my database isn't properly fed. => not enough time
* Some phpstan errors aren't fixed => lack of time

# What was not done and why
* I did not applied DDD or Hexagonal Architecture as it would be time consuming and maybe overkill for a project of this size.
* I did not upgrade PHP to latest version `8.2`, and so could not use some features like readonly classes => not enough time.
* I did not change doctrine annotations to php attributes => not enough time.
* Add tests to CI : time consuming and not asked for this project, but would have been nice.
* Use Behat for functional tests : time consuming.
* Add functional tests for existing controllers => not enough time
* Update dependencies => not enough time and complicated to see the side effects on controllers without tests on them.

# Picture of a cute animal (learned this from Bedrock talks 😄 )
![DALL·E 2022-12-19 23 32 01](https://user-images.githubusercontent.com/6156286/208539549-e954c9e4-f737-4ab6-bf2c-275bff593491.png)
